### PR TITLE
SSE raw data retrived and parsed.

### DIFF
--- a/test_lister.py
+++ b/test_lister.py
@@ -29,10 +29,10 @@ lister = TickerLister('equities_db/lists/', 1)
 # full_list_nasdaq = lister.list_full_nasdaq(True)
 # full_list_amex = lister.list_full_amex(True)
 
-# full_list_sse = lister.list_full_sse(True) #issue with excel file
+full_list_sse = lister.list_full_sse(False) #issue with excel file
 # full_list_szse = lister.list_full_szse( False )
 
-full_list_tyo = lister.list_full_tyo( True )
+# full_list_tyo = lister.list_full_tyo( True )
 
 # for l in full_list_nse[0:3]:
 #     print l


### PR DESCRIPTION
XMLHTTP request for shanghai downloaded and processed.
Now lister can give out shanghai-listed stock list.

So, in all the supported listers are: HK, NSE, BSE, NYSE, NASDAQ, AMEX, TYO, SSE, SZSE.

TODO:
- Retrive wsj data for SSE and SZSE.
- Get quotes data for SSE and SZSE